### PR TITLE
Add a note to the readme about which files to point your DAW at

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ find "$HOME/.wine/drive_c/Program Files/Steinberg/VstPlugins" -type f -iname '*.
   xargs -0 -n1 cp "$yabridge_home/libyabridge.so"
 ```
 
+### Running plugins
+
+Finally, select and open the plugin in your desired wine prefix from your DAW.
+
 ## Runtime dependencies and known issues
 
 Any VST2 plugin should function out of the box, although some plugins will need


### PR DESCRIPTION
Being a total noob here, I had no idea which files to point my DAW (Bitwig Studio) at. I started with the `yabridge-host*.exe` files but it had no idea what those were.

Only by looking at the Quickstart guide of [linvst](https://github.com/osxmidi/LinVst) did it click that I needed to point it at the files in my `~/.wine` directory.

Hopefully this small note should do the same for others. Please revise it or make suggestions if things could be clearer.