### PR TITLE
Clarify that yabridgectl isn't a standalone thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ on how to use Wine to install Windows applications, check out Wine's
 
 ### Automatic setup (recommended)
 
-The easiest way to get up and running is through
+The easiest way to get up and running is by using
 [yabridgectl](https://github.com/robbert-vdh/yabridge/tree/master/tools/yabridgectl).
-You can download yabridgectl from GitHub's [releases
+Download yabridgectl and yabridge (which it controls) from GitHub's [releases
 page](https://github.com/robbert-vdh/yabridge/releases). There are also AUR
 packages available if you're running Arch or Manjaro
 ([yabridgectl](https://aur.archlinux.org/packages/yabridgectl/),


### PR DESCRIPTION
I'm just remembering that this was confusing to me the first time;
it was recommending a 'simpler' way of doing things through yabridgectl.  I didn't understand that that was a wrapper around the underlying yabridge.

Could you just package them together as a single 'yabridge' download? 
i.e. do you have users who want yabridge but not yabridgectl?