### PR TITLE
Update actions to fix deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     # these steps
     # https://github.community/t5/GitHub-Actions/reusing-sharing-inheriting-steps-between-jobs-declarations/td-p/37849
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Needed for git-describe to do anything useful, the safe directory
       # workaround is needed for https://github.com/actions/runner/issues/2033
       - name: Fetch all git history
@@ -61,7 +61,7 @@ jobs:
 
           tar -caf "$ARCHIVE_NAME" yabridge
           rm -rf yabridge
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARCHIVE_NAME }}
           path: ${{ env.ARCHIVE_NAME }}
@@ -73,7 +73,7 @@ jobs:
     outputs:
       artifact-name: ${{ env.ARCHIVE_NAME }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Needed for git-describe to do anything useful, the safe directory
       # workaround is needed for https://github.com/actions/runner/issues/2033
       - name: Fetch all git history
@@ -103,7 +103,7 @@ jobs:
 
           tar -caf "$ARCHIVE_NAME" yabridge
           rm -rf yabridge
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARCHIVE_NAME }}
           path: ${{ env.ARCHIVE_NAME }}
@@ -118,7 +118,7 @@ jobs:
     outputs:
       artifact-name: ${{ env.ARCHIVE_NAME }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Needed for git-describe to do anything useful, the safe directory
       # workaround is needed for https://github.com/actions/runner/issues/2033
       - name: Fetch all git history
@@ -148,7 +148,7 @@ jobs:
 
           tar -caf "$ARCHIVE_NAME" yabridge
           rm -rf yabridge
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARCHIVE_NAME }}
           path: ${{ env.ARCHIVE_NAME }}
@@ -162,7 +162,7 @@ jobs:
       run:
         working-directory: tools/yabridgectl
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Needed for git-describe to do anything useful, the safe directory
       # workaround is needed for https://github.com/actions/runner/issues/2033
       - name: Fetch all git history
@@ -189,7 +189,7 @@ jobs:
 
           tar -caf "$ARCHIVE_NAME" yabridgectl
           rm -rf yabridgectl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARCHIVE_NAME }}
           # For some reason there's no way to tell GitHub actions to run actions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,11 +173,7 @@ jobs:
         run: |
           echo "ARCHIVE_NAME=yabridgectl-$(git describe --always).tar.gz" >> "$GITHUB_ENV"
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          default: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Build the binaries
         run: cargo build --release
       - name: Strip remaining debug symbols


### PR DESCRIPTION
Updates actions to their latest releases to fix _NodeJS 12_ and `set-output` deprecations.

`actions-rs/toolchain` replaced as it's effectively no longer maintained and wont receive fixes (https://github.com/actions-rs/toolchain/issues/219).

:warning: **Note:** Ubuntu 18.04 images are deprecated too, with removal planed for early next year. It's worth to consider an update to 20.04 / 22.04.