### PR TITLE
Fix not being able to change path

### DIFF
--- a/tools/yabridgectl/src/main.rs
+++ b/tools/yabridgectl/src/main.rs
@@ -148,7 +148,8 @@ fn main() -> Result<()> {
                             "Automatically locate yabridge's files. This can be used after \
                              manually setting a path with the '--path' option to revert back to \
                              the default auto detection behaviour.",
-                        ),
+                        )
+                        .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("vst2_location")


### PR DESCRIPTION
Without this patch I get
```
thread 'main' panicked at /github/home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.3.21/src/parser/matches/arg_matches.rs:181:17:
arg `path_auto`'s `ArgAction` should be one of `SetTrue`, `SetFalse` which should provide a default
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```