### PR TITLE
Work around wrong offset in plugin windows

### DIFF
--- a/src/wine-host/editor.cpp
+++ b/src/wine-host/editor.cpp
@@ -475,7 +475,7 @@ void Editor::handle_x11_events() noexcept {
                                std::to_string(event->event);
                     });
 
-		    redetect_host_window();
+                    redetect_host_window();
 
                     // If the `editor_force_dnd` option is set, we'll strip
                     // `XdndAware` from all of `wine_window_`'s ancestors

--- a/src/wine-host/editor.cpp
+++ b/src/wine-host/editor.cpp
@@ -417,6 +417,27 @@ void Editor::show() noexcept {
     ShowWindow(win32_window_.handle_, SW_SHOWNORMAL);
 }
 
+std::array<int16_t, 2> Editor::get_parent_window_offset() {
+
+    xcb_generic_error_t* error = nullptr;
+    const xcb_window_t root =
+        get_root_window(*x11_connection_, parent_window_);
+    const xcb_translate_coordinates_cookie_t coord_cookie =
+        xcb_translate_coordinates(x11_connection_.get(), parent_window_, root, 0, 0);
+    const std::unique_ptr<xcb_translate_coordinates_reply_t> coord_reply(
+        xcb_translate_coordinates_reply(x11_connection_.get(), coord_cookie, &error));
+    THROW_X11_ERROR(error);
+
+    logger_.log_editor_trace([&]() {
+        return "DEBUG: Parent window offset " +
+        std::to_string(coord_reply->dst_x) +
+        "x" +
+        std::to_string(coord_reply->dst_y);
+    });
+    return {coord_reply->dst_x, coord_reply->dst_y};
+}
+
+
 void Editor::handle_x11_events() noexcept {
     // NOTE: Ardour will unmap the window instead of closing the editor. When
     //       the window is unmapped `wine_window_` doesn't exist and any X11
@@ -454,7 +475,6 @@ void Editor::handle_x11_events() noexcept {
                                ", generated from " +
                                std::to_string(event->event);
                     });
-
                     redetect_host_window();
 
                     // If the `editor_force_dnd` option is set, we'll strip
@@ -559,6 +579,11 @@ void Editor::handle_x11_events() noexcept {
                             parent_window_ != host_window_) {
                             translated_event.x += host_window_config_.x;
                             translated_event.y += host_window_config_.y;
+                        }
+                        if (!is_synthetic_event) {
+                            const std::array<int16_t, 2> offset = get_parent_window_offset();
+                            translated_event.x = offset[0];
+                            translated_event.y = offset[1];
                         }
                         logger_.log_editor_trace([&]() {
                             return "DEBUG: Translated coords: " +

--- a/src/wine-host/editor.cpp
+++ b/src/wine-host/editor.cpp
@@ -437,7 +437,6 @@ std::array<int16_t, 2> Editor::get_parent_window_offset() {
     return {coord_reply->dst_x, coord_reply->dst_y};
 }
 
-
 void Editor::handle_x11_events() noexcept {
     // NOTE: Ardour will unmap the window instead of closing the editor. When
     //       the window is unmapped `wine_window_` doesn't exist and any X11
@@ -475,7 +474,8 @@ void Editor::handle_x11_events() noexcept {
                                ", generated from " +
                                std::to_string(event->event);
                     });
-                    redetect_host_window();
+
+		    redetect_host_window();
 
                     // If the `editor_force_dnd` option is set, we'll strip
                     // `XdndAware` from all of `wine_window_`'s ancestors

--- a/src/wine-host/editor.cpp
+++ b/src/wine-host/editor.cpp
@@ -160,6 +160,20 @@ std::optional<xcb_window_t> find_host_window(xcb_connection_t& x11_connection,
                                              xcb_atom_t xcb_wm_state_property);
 
 /**
+ * Uses xcb_query_tree to find out what the parent of the given window is. This
+ * seems to be able to find the host if find_host_window fails.
+ *
+ * @param x11_connection The X11 connection to use.
+ * @param window_id The window we want to know the parent window of.
+ *
+ * @return The host's editor window, or a nullopt if we cannot find a valid
+ *   window.
+ */
+std::optional<xcb_window_t> find_host_window_from_query_tree(
+    xcb_connection_t& x11_connection,
+    xcb_window_t window_id);
+
+/**
  * Check whether `child` is a descendant of `parent` or the same window. Used
  * during focus checks to only grab focus when needed.
  *
@@ -1003,7 +1017,10 @@ void Editor::redetect_host_window() noexcept {
     const xcb_window_t new_host_window =
         find_host_window(*x11_connection_, parent_window_,
                          xcb_wm_window_role_property_)
-            .value_or(parent_window_);
+            .value_or(find_host_window_from_query_tree(*x11_connection_,
+                                                       parent_window_)
+                          .value_or(parent_window_));
+
     if (new_host_window == host_window_) {
         return;
     }
@@ -1251,6 +1268,28 @@ std::optional<xcb_window_t> find_host_window(
         if (property_reply->type != XCB_NONE) {
             return *window;
         }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<xcb_window_t> find_host_window_from_query_tree(
+    xcb_connection_t& x11_connection,
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    const xcb_window_t window_id) {
+    const xcb_query_tree_cookie_t cookie =
+        xcb_query_tree(&x11_connection, window_id);
+    xcb_generic_error_t* error = nullptr;
+    const std::unique_ptr<xcb_query_tree_reply_t, decltype(&free)> reply(
+        xcb_query_tree_reply(&x11_connection, cookie, &error), free);
+
+    if (!error && reply) {
+        if (const xcb_window_t actual_parent = reply->parent;
+            actual_parent != XCB_NONE) {
+            return actual_parent;
+            }
+    } else {
+        free(error);
     }
 
     return std::nullopt;

--- a/src/wine-host/editor.h
+++ b/src/wine-host/editor.h
@@ -312,6 +312,11 @@ class Editor {
     void redetect_host_window() noexcept;
 
     /**
+     * Get offset of parent window to fix mouse coordinates.
+     */
+    std::array<int16_t, 2> get_parent_window_offset();
+
+    /**
      * Reparent `child` to `new_parent`. This includes the flush.
      */
     void do_reparent(xcb_window_t child, xcb_window_t new_parent) const;


### PR DESCRIPTION
This PR works around the issue of wrong mouse cursor positions as mentioned in #409 by getting the parent window offset via xcb and using that when no "synthetic" ConfigureNotify event with absolute coordinates is present.

Tested this with wine-10.20 and various (mostly VST3) plugins in Bitwig, Carla, Reaper and Ardour using gnome with Xwayland.