### PR TITLE
Fix some VST3 resizing issues

### DIFF
--- a/src/wine-host/bridges/vst3-impls/plug-frame-proxy.cpp
+++ b/src/wine-host/bridges/vst3-impls/plug-frame-proxy.cpp
@@ -52,8 +52,18 @@ Vst3PlugFrameProxyImpl::resizeView(Steinberg::IPlugView* /*view*/,
         // We have to use this special sending function here so we can handle
         // calls to `IPlugView::onSize()` from this same thread (the UI thread).
         // See the docstring for more information.
-        return bridge_.send_mutually_recursive_message(YaPlugFrame::ResizeView{
-            .owner_instance_id = owner_instance_id(), .new_size = *newSize});
+        const tresult result =
+            bridge_.send_mutually_recursive_message(YaPlugFrame::ResizeView{
+                .owner_instance_id = owner_instance_id(), .new_size = *newSize});
+
+        // Some hosts (like Carla) don't call onSize() after accepting a
+        // resizeView() request. This causes the plugin to not know about its
+        // new size, so it doesn't draw beyond the original size. Call the
+        // plugin's onSize() ourselves to ensure it knows the new size. If the
+        // host already called onSize(), this will be a harmless duplicate call.
+        bridge_.notify_plugin_on_new_size(owner_instance_id(), *newSize);
+
+        return result;
     } else {
         std::cerr
             << "WARNING: Null pointer passed to 'IPlugFrame::resizeView()'"

--- a/src/wine-host/bridges/vst3.cpp
+++ b/src/wine-host/bridges/vst3.cpp
@@ -806,9 +806,38 @@ void Vst3Bridge::run() {
                             initial_size.emplace(size.getWidth(),
                                                  size.getHeight());
                         }
+
+                        // HACK: Create a resize watchdog that periodically
+                        // verifies the wrapper window size matches the expected
+                        // size. This works around VST3 resize issues (mostly)
+                        // in Ardour during mutual recursion where X11
+                        // operations may not be applied and the wrapper window
+                        // remains smaller or larger than the wine window. The
+                        // goal here is eventual consistency
+                        auto resize_watchdog = [&instance = instance] {
+                            if (instance.editor) {
+                                if (const auto expected =
+                                        instance.editor
+                                            ->check_size_mismatch()) {
+                                    // Resize the plugin view to propagate the
+                                    // target size everywhere.
+                                    if (instance.plug_view_instance) {
+                                        Steinberg::ViewRect rect{
+                                            0, 0,
+                                            (expected->width),
+                                            (expected->height)};
+                                        instance.plug_frame_proxy->resizeView(
+                                            instance.plug_view_instance
+                                                ->plug_view,
+                                            &rect);
+                                    }
+                                }
+                            }
+                        };
+
                         Editor& editor_instance = instance.editor.emplace(
                             main_context_, config_, generic_logger_, x11_handle,
-                            std::nullopt, initial_size);
+                            std::move(resize_watchdog), initial_size);
                         const tresult result =
                             instance.plug_view_instance->plug_view->attached(
                                 editor_instance.win32_handle(), type.c_str());

--- a/src/wine-host/bridges/vst3.cpp
+++ b/src/wine-host/bridges/vst3.cpp
@@ -1388,6 +1388,26 @@ bool Vst3Bridge::resize_editor(size_t instance_id,
     }
 }
 
+void Vst3Bridge::notify_plugin_on_new_size(size_t instance_id,
+                                           Steinberg::ViewRect& new_size) {
+    const auto& [instance, _] = get_instance(instance_id);
+
+    if (instance.plug_view_instance) {
+        // Skip if the host already called onSize() with this size during
+        // resizeView(). This is detected by checking if last_set_size already
+        // matches new_size (the OnSize handler updates last_set_size).
+        if (instance.last_set_size.getWidth() == new_size.getWidth() &&
+            instance.last_set_size.getHeight() == new_size.getHeight()) {
+            return;
+        }
+
+        instance.plug_view_instance->plug_view->onSize(&new_size);
+
+        // Update last_set_size so getSize() returns consistent values
+        instance.last_set_size = new_size;
+    }
+}
+
 void Vst3Bridge::register_context_menu(Vst3ContextMenuProxyImpl& context_menu) {
     const auto& [owner_instance, _] =
         get_instance(context_menu.owner_instance_id());

--- a/src/wine-host/bridges/vst3.cpp
+++ b/src/wine-host/bridges/vst3.cpp
@@ -801,8 +801,13 @@ void Vst3Bridge::run() {
                     .run_in_context([&, &instance = instance]() -> tresult {
                         Steinberg::ViewRect size;
                         std::optional<Size> initial_size;
+                        // Only accept the initial size from the plugin if it's
+                        // valid. Some plugins like Spectrasonics' Omnisphere 2
+                        // return 0x0 for the initial size, which breaks our
+                        // reparenting in the editor.
                         if (instance.plug_view_instance->plug_view->getSize(
-                                &size) == Steinberg::kResultOk) {
+                                &size) == Steinberg::kResultOk &&
+                            size.getWidth() > 0 && size.getHeight() > 0) {
                             initial_size.emplace(size.getWidth(),
                                                  size.getHeight());
                         }

--- a/src/wine-host/bridges/vst3.h
+++ b/src/wine-host/bridges/vst3.h
@@ -319,6 +319,14 @@ class Vst3Bridge : public HostBridge {
     bool resize_editor(size_t instance_id, const Steinberg::ViewRect& new_size);
 
     /**
+     * Notify the plugin of its new size by calling `IPlugView::onSize()`.
+     * This is called after `resize_editor()` for hosts that don't call
+     * `onSize()` after accepting a `resizeView()` request (like Carla).
+     */
+    void notify_plugin_on_new_size(size_t instance_id,
+                                   Steinberg::ViewRect& new_size);
+
+    /**
      * Register a context with with `context_menu`'s ID and owner in
      * `object_instances`. This will be called during the constructor of
      * `Vst3ContextMenuProxyImpl` so we can refer to the exact instance later.

--- a/src/wine-host/editor.cpp
+++ b/src/wine-host/editor.cpp
@@ -418,7 +418,7 @@ void Editor::resize(uint16_t width, uint16_t height) {
     // `handle_x11_events()`
     SetWindowPos(
         win32_window_.handle_, nullptr, 0, 0, width, height,
-        SWP_NOREPOSITION | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_DEFERERASE);
+        SWP_NOREPOSITION | SWP_NOACTIVATE | SWP_DEFERERASE | SWP_NOMOVE);
 
     // NOTE: This lets us skip resize requests in CLAP plugins when the plugin
     //       tries to resize to its current size. This fixes resize loops when

--- a/src/wine-host/editor.cpp
+++ b/src/wine-host/editor.cpp
@@ -427,6 +427,34 @@ void Editor::resize(uint16_t width, uint16_t height) {
     wrapper_window_size_.height = height;
 }
 
+std::optional<Size> Editor::check_size_mismatch() {
+    xcb_generic_error_t* error = nullptr;
+    const xcb_get_geometry_cookie_t cookie =
+        xcb_get_geometry(x11_connection_.get(), wrapper_window_.window_);
+    const std::unique_ptr<xcb_get_geometry_reply_t> geom(
+        xcb_get_geometry_reply(x11_connection_.get(), cookie, &error));
+
+    if (error) {
+        free(error);
+        return std::nullopt;
+    }
+
+    if (geom && (geom->width != wrapper_window_size_.width ||
+                 geom->height != wrapper_window_size_.height)) {
+        logger_.log_editor_trace([&]() {
+            return "DEBUG: Size mismatch detected. Actual: " +
+                   std::to_string(geom->width) + "x" +
+                   std::to_string(geom->height) + ", Expected: " +
+                   std::to_string(wrapper_window_size_.width) + "x" +
+                   std::to_string(wrapper_window_size_.height);
+        });
+
+        return wrapper_window_size_;
+    }
+
+    return std::nullopt;
+}
+
 void Editor::show() noexcept {
     ShowWindow(win32_window_.handle_, SW_SHOWNORMAL);
 }

--- a/src/wine-host/editor.h
+++ b/src/wine-host/editor.h
@@ -205,6 +205,15 @@ class Editor {
     void resize(uint16_t width, uint16_t height);
 
     /**
+     * Check if the wrapper window's actual X11 size matches the expected size.
+     * Returns the expected size if there's a mismatch, or nullopt if sizes
+     * match. This is used as a workaround for VST3 plugins where rapid
+     * resizing during mutual recursion can cause the X11 window to get stuck
+     * at an intermediate size.
+     */
+    std::optional<Size> check_size_mismatch();
+
+    /**
      * Show the window, should be called after the plugin has embedded itself.
      * There's absolutely zero reason why this can't be done in the constructor,
      * but it can't be. Thanks Waves.


### PR DESCRIPTION
This fixes some of the VST3 resizing issues in the current `new-wine10-embedding` branch. Namely the completely broken resizing in Ardour and the inability to make plugins larger in Carla. Tested in Bitwig, Reaper, Ardour, Carla and Tracktion Waveform. 

With this resizing works in all the tested DAWs/plugin hosts although it's the clunkiest in Reaper, so there's no change there from these changes. The parent window just fails to resize sometimes in Reaper and I gave up on trying to figure it out for now since the resizing does work and you can always reopen the plugin window or switch to another plugin to resolve it.