### PR TITLE
vst3: dispatch IConnectionPoint::connect on the GUI thread

### DIFF
--- a/src/wine-host/bridges/vst3.cpp
+++ b/src/wine-host/bridges/vst3.cpp
@@ -303,32 +303,45 @@ void Vst3Bridge::run() {
                 // on the Wine side. If we cannot do that, then we'll still go
                 // through the host's connection proxy connection proxy (and
                 // we'll end up proxying the host's connection proxy).
-                return std::visit(
-                    overload{
-                        [&](const native_size_t& other_instance_id) -> tresult {
-                            const auto& [this_instance, _] =
-                                get_instance(request.instance_id);
-                            const auto& [other_instance, _2] =
-                                get_instance(other_instance_id);
+                //
+                // Run on the GUI thread so any threadlocal Win32 timers the
+                // plugin spawns from inside `connect()` (e.g. VSTGUI/VST3 SDK
+                // update pumps registered when the IConnectionPoint pair is
+                // wired up) are bound to the thread that actually pumps Win32
+                // messages. Otherwise the timers stay queued on yabridge's
+                // Asio worker thread which has no message loop, and any UI
+                // that depends on them (e.g. Serum 2's keyboard updating
+                // from the audio thread) never refreshes.
+                return do_mutual_recursion_on_gui_thread([&]() -> tresult {
+                    return std::visit(
+                        overload{
+                            [&](const native_size_t& other_instance_id)
+                                -> tresult {
+                                const auto& [this_instance, _] =
+                                    get_instance(request.instance_id);
+                                const auto& [other_instance, _2] =
+                                    get_instance(other_instance_id);
 
-                            return this_instance.interfaces.connection_point
-                                ->connect(
-                                    other_instance.interfaces.connection_point);
-                        },
-                        [&](Vst3ConnectionPointProxy::ConstructArgs& args)
-                            -> tresult {
-                            const auto& [this_instance, _] =
-                                get_instance(request.instance_id);
+                                return this_instance.interfaces.connection_point
+                                    ->connect(other_instance.interfaces
+                                                  .connection_point);
+                            },
+                            [&](Vst3ConnectionPointProxy::ConstructArgs& args)
+                                -> tresult {
+                                const auto& [this_instance, _] =
+                                    get_instance(request.instance_id);
 
-                            this_instance.connection_point_proxy =
-                                Steinberg::owned(
-                                    new Vst3ConnectionPointProxyImpl(
-                                        *this, std::move(args)));
+                                this_instance.connection_point_proxy =
+                                    Steinberg::owned(
+                                        new Vst3ConnectionPointProxyImpl(
+                                            *this, std::move(args)));
 
-                            return this_instance.interfaces.connection_point
-                                ->connect(this_instance.connection_point_proxy);
-                        }},
-                    request.other);
+                                return this_instance.interfaces.connection_point
+                                    ->connect(
+                                        this_instance.connection_point_proxy);
+                            }},
+                        request.other);
+                });
             },
             [&](const YaConnectionPoint::Disconnect& request)
                 -> YaConnectionPoint::Disconnect::Response {

--- a/src/wine-host/bridges/vst3.cpp
+++ b/src/wine-host/bridges/vst3.cpp
@@ -408,10 +408,17 @@ void Vst3Bridge::run() {
             },
             [&](YaEditController::SetComponentState& request)
                 -> YaEditController::SetComponentState::Response {
-                const auto& [instance, _] = get_instance(request.instance_id);
+                // VST3 spec requires this to run on the UI thread (it's a
+                // plugin-exported function and not in the audio-thread
+                // exception list). See:
+                // https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/API+Documentation/Index.html#vst-3-threading-model
+                return do_mutual_recursion_on_gui_thread([&]() -> tresult {
+                    const auto& [instance, _] =
+                        get_instance(request.instance_id);
 
-                return instance.interfaces.edit_controller->setComponentState(
-                    &request.state);
+                    return instance.interfaces.edit_controller
+                        ->setComponentState(&request.state);
+                });
             },
             [&](const YaEditController::GetParameterInfos& request)
                 -> YaEditController::GetParameterInfos::Response {
@@ -509,23 +516,31 @@ void Vst3Bridge::run() {
             },
             [&](YaEditController::SetComponentHandler& request)
                 -> YaEditController::SetComponentHandler::Response {
-                const auto& [instance, _] = get_instance(request.instance_id);
+                // VST3 spec requires this to run on the UI thread.
+                return do_mutual_recursion_on_gui_thread([&]() -> tresult {
+                    const auto& [instance, _] =
+                        get_instance(request.instance_id);
 
-                // If the host passed a valid component handler, then we'll
-                // create a proxy object for the component handler and pass that
-                // to the initialize function. The lifetime of this object is
-                // tied to that of the actual plugin object we're proxying for.
-                // Otherwise we'll also pass a null pointer. This often happens
-                // just before the host terminates the plugin.
-                instance.component_handler_proxy =
-                    request.component_handler_proxy_args
-                        ? Steinberg::owned(new Vst3ComponentHandlerProxyImpl(
-                              *this,
-                              std::move(*request.component_handler_proxy_args)))
-                        : nullptr;
+                    // If the host passed a valid component handler, then
+                    // we'll create a proxy object for the component handler
+                    // and pass that to the initialize function. The lifetime
+                    // of this object is tied to that of the actual plugin
+                    // object we're proxying for. Otherwise we'll also pass a
+                    // null pointer. This often happens just before the host
+                    // terminates the plugin.
+                    instance.component_handler_proxy =
+                        request.component_handler_proxy_args
+                            ? Steinberg::owned(
+                                  new Vst3ComponentHandlerProxyImpl(
+                                      *this, std::move(
+                                                 *request
+                                                      .component_handler_proxy_args)))
+                            : nullptr;
 
-                return instance.interfaces.edit_controller->setComponentHandler(
-                    instance.component_handler_proxy);
+                    return instance.interfaces.edit_controller
+                        ->setComponentHandler(
+                            instance.component_handler_proxy);
+                });
             },
             [&](const YaEditController::CreateView& request)
                 -> YaEditController::CreateView::Response {
@@ -1203,18 +1218,25 @@ void Vst3Bridge::run() {
             },
             [&](YaPluginFactory3::SetHostContext& request)
                 -> YaPluginFactory3::SetHostContext::Response {
-                plugin_factory_host_context_ =
-                    Steinberg::owned(new Vst3HostContextProxyImpl(
-                        *this, std::move(request.host_context_args)));
+                // VST3 spec requires this to run on the UI thread.
+                return main_context_
+                    .run_in_context([&]() -> tresult {
+                        plugin_factory_host_context_ =
+                            Steinberg::owned(new Vst3HostContextProxyImpl(
+                                *this,
+                                std::move(request.host_context_args)));
 
-                Steinberg::FUnknownPtr<Steinberg::IPluginFactory3> factory_3(
-                    module_->getFactory().get());
-                assert(factory_3);
+                        Steinberg::FUnknownPtr<Steinberg::IPluginFactory3>
+                            factory_3(module_->getFactory().get());
+                        assert(factory_3);
 
-                // This static cast is required to upcast to `FUnknown*`
-                return factory_3->setHostContext(
-                    static_cast<YaHostApplication*>(
-                        plugin_factory_host_context_));
+                        // This static cast is required to upcast to
+                        // `FUnknown*`
+                        return factory_3->setHostContext(
+                            static_cast<YaHostApplication*>(
+                                plugin_factory_host_context_));
+                    })
+                    .get();
             },
             [&](const YaUnitInfo::GetUnitCount& request)
                 -> YaUnitInfo::GetUnitCount::Response {


### PR DESCRIPTION
## Symptom

When loading **Serum 2** (Xfer, VST3, built against newer VSTGUI ~4.12+) through yabridge under REAPER on Linux:

- the on-screen MIDI keyboard never visualises notes coming in from the audio thread or from clicking the keyboard itself (sound plays, but keys don't light up)
- env drag&drop has no live feedback while dragging
- some animated visualisations (Chaos: Rossler, certain OSC views) are either frozen or extremely sluggish
- general GUI feels unresponsive

Reproduces with both `"Disable DirectComposition": true` and `false` in Serum 2's prefs. Serum 1 (older VSTGUI on the same setup) is **not** affected.

## What I found

I instrumented Wine's `NtUserSetTimer` and `peek_message` with a small ERR-log patch and ran the same Serum 2 session in two configurations:

| Setup | `SetTimer(NULL, ...)` registered (per Wine TID) | WM_TIMER pulled from queue (per TID) |
|-------|------------------------------------------------|--------------------------------------|
| `wine reaper.exe` (REAPER itself in Wine) | all 6 plugin timers on GUI thread `0x24` | all 6 pulled on `0x24` |
| yabridge + native REAPER | 5 on GUI thread `0x24`, **1 on worker thread `0x368`** (16 ms timeout) | 5 pulled on `0x24`, **0 pulled on `0x368`** |

Worker thread `0x368` is the asio worker that handles incoming VST3 socket messages. It has no Win32 message loop, so any threadlocal `SetTimer(NULL, …)` bound to it stays queued forever and the corresponding `TIMERPROC` never fires.

The single 16 ms timer that ends up on the worker thread is registered by the plugin from inside `IConnectionPoint::connect()` (presumably an internal update pump that the newer VSTGUI / VST3 SDK wires up when the component ↔ controller pair is connected). In `wine reaper.exe` the same `connect()` runs on the host GUI thread, so the timer is bound to a thread that *does* pump messages and everything works.

## The fix

Wrap the `YaConnectionPoint::Connect` handler with `do_mutual_recursion_on_gui_thread`, mirroring what's already done for `Vst3PluginProxy::Initialize` and `YaEditController::CreateView`. The mutual-recursion variant is needed because component ↔ controller can recurse through `connect()`.

After the patch:
- keyboard updates correctly
- env drag&drop, Chaos: Rossler, OSC views all become responsive
- general Serum 2 GUI is noticeably smoother

I haven't seen any regressions in my normal session (Serum 1, WineSynth, JUCE-based plugins). Would appreciate review on whether the mutual-recursion guard is the right primitive here vs. a plain `main_context_.run_in_context`.

## Open question — scope

A handful of other init-time handlers are still dispatched on the worker thread:

- `YaEditController::SetComponentState`
- `YaEditController::SetComponentHandler`
- `IPluginFactory3::setHostContext`

Serum 2 doesn't seem to register problematic timers from those, but other plugins built against the same VSTGUI/VST3 SDK update mechanism could. Happy to extend this PR to cover them if you'd prefer the conservative fix, but I haven't been able to reproduce the failure mode through any of those calls so I left them alone for now.

## Reproduction

Serum 2 has a free demo,
so anyone can verify before/after:

1. Install the Serum 2 demo in a Wine prefix
2. (Optional) Set `Xfer/Serum 2/Serum2Prefs.json`: `"Disable DirectComposition": true`
   to test the GDI path as well — bug reproduces in both modes
3. Load Serum 2 as a VST3 in native REAPER through yabridge
4. Trigger MIDI notes (mouse-click the on-screen keyboard or via a MIDI track)
5. Without patch: keys never highlight, modulators don't update, env drag&drop
   has no live feedback. With patch: everything updates correctly.

Note: Serum 2 needs a patched Wine to render its D2D1 GUI at all (otherwise
the editor stays blank / corrupted). The patch set I use is on
https://github.com/giang17/wine/tree/d2d1-dcomp-11.0 (Wine 11.0 base + ~15
D2D1 patches + DComp/DWrite/winex11 fixes).
