### PR TITLE
Make the audio thread's fallback SCHED_FIFO priority configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added a `YABRIDGE_FALLBACK_RT_PRIORITY` environment variable to change the
+  `SCHED_FIFO` priority yabridge's realtime threads are created at before the
+  priority the host uses on its own audio threads is known. This still defaults
+  to 5, and it's only useful on systems that treat realtime priority as a
+  scheduling or CPU placement signal. See the [performance
+  tuning](https://github.com/robbert-vdh/yabridge#performance-tuning) section of
+  the readme for more information.
+
 ### Fixed
 
 - Fixed a compatibility issue with **Wine 9.22** and above that caused mouse

--- a/README.md
+++ b/README.md
@@ -742,6 +742,21 @@ negative side effects:
   `preempt=full` kernel parameter or better yet, switch to a kernel that's
   optimized for low latencies.
 
+- If your setup treats realtime priority as a scheduling or CPU placement signal
+  — for instance a helper that keeps only threads above a certain `rtprio` on
+  your fastest cores — then you may want to set the
+  `YABRIDGE_FALLBACK_RT_PRIORITY` environment variable. yabridge creates its
+  audio threads with a `SCHED_FIFO` priority of 5 and then periodically copies
+  the priority the host uses on its own audio threads, but everything that runs
+  on those threads before the first process call still runs at that initial
+  priority. For some plugins that includes an expensive activation. Setting this
+  variable to a value above your own threshold makes that initial priority match
+  what the thread will end up at anyway. The value is clamped to the valid
+  `SCHED_FIFO` range and to your `rtprio` limit, and it defaults to 5. See the
+  [environment configuration](#environment-configuration) section below for more
+  information on where to set this environment variable so that it gets picked
+  up when you start your DAW.
+
 - You can also try enabling the `threadirqs` kernel parameter and using which
   can in some situations help with xruns. After enabling this, you can use
   [rtirq](https://github.com/rncbc/rtirq#rtirq) to increase the priority of

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -17,6 +17,7 @@
 #include "utils.h"
 
 #include <stdlib.h>
+#include <algorithm>
 
 #include <sched.h>
 #include <xmmintrin.h>
@@ -39,6 +40,19 @@ constexpr char disable_watchdog_timer_env_var[] = "YABRIDGE_NO_WATCHDOG";
  */
 constexpr char temp_dir_override_env_var[] = "YABRIDGE_TEMP_DIR";
 
+/**
+ * If this environment variable is set to a number, then we'll use that as the
+ * initial `SCHED_FIFO` priority for our realtime threads instead of the
+ * default of 5. See `fallback_realtime_priority()`.
+ */
+constexpr char fallback_rt_priority_env_var[] = "YABRIDGE_FALLBACK_RT_PRIORITY";
+
+/**
+ * The initial `SCHED_FIFO` priority used when
+ * `fallback_rt_priority_env_var` is unset or doesn't contain a number.
+ */
+constexpr int default_fallback_rt_priority = 5;
+
 fs::path get_temporary_directory() {
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
     if (const auto directory = getenv(temp_dir_override_env_var)) {
@@ -59,6 +73,48 @@ std::optional<int> get_realtime_priority() noexcept {
     } else {
         return std::nullopt;
     }
+}
+
+int fallback_realtime_priority() noexcept {
+    // The environment doesn't get modified anywhere, so we can parse this once
+    // and keep using the result. This is important because this function is
+    // also called from realtime threads.
+    static const int priority = []() -> int {
+        // This is safe because we're not storing the pointer anywhere and the
+        // environment doesn't get modified anywhere
+        // NOLINTNEXTLINE(concurrency-mt-unsafe)
+        const char* env_value = getenv(fallback_rt_priority_env_var);
+        if (!env_value || *env_value == '\0') {
+            return default_fallback_rt_priority;
+        }
+
+        // `strtol()` is used instead of `std::stoi()` because this function is
+        // `noexcept`. Anything that isn't a plain number is ignored.
+        char* parse_end = nullptr;
+        const long parsed_priority = strtol(env_value, &parse_end, 10);
+        if (*parse_end != '\0') {
+            return default_fallback_rt_priority;
+        }
+
+        // Clamping means a nonsensical value can't cause
+        // `sched_setscheduler()` to fail outright, leaving the thread on
+        // `SCHED_OTHER`. `RLIMIT_RTPRIO` is taken into account as well since
+        // that's usually lower than the scheduler's own maximum.
+        long max_priority = sched_get_priority_max(SCHED_FIFO);
+        rlimit rtprio_limit{};
+        if (getrlimit(RLIMIT_RTPRIO, &rtprio_limit) == 0 &&
+            rtprio_limit.rlim_cur != RLIM_INFINITY &&
+            static_cast<long>(rtprio_limit.rlim_cur) < max_priority) {
+            max_priority = static_cast<long>(rtprio_limit.rlim_cur);
+        }
+
+        return static_cast<int>(
+            std::clamp(parsed_priority,
+                       static_cast<long>(sched_get_priority_min(SCHED_FIFO)),
+                       max_priority));
+    }();
+
+    return priority;
 }
 
 bool set_realtime_priority(bool sched_fifo, int priority) noexcept {

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -87,16 +87,30 @@ ghc::filesystem::path get_temporary_directory();
 std::optional<int> get_realtime_priority() noexcept;
 
 /**
- * Set the scheduling policy to `SCHED_FIFO` with priority 5 for this process.
- * We explicitly don't do this for wineserver itself since from my testing that
- * can actually increase latencies.
+ * The `SCHED_FIFO` priority we create our realtime threads at before we know
+ * which priority the host uses for its own audio threads. This is 5 by default,
+ * but it can be overridden through the `YABRIDGE_FALLBACK_RT_PRIORITY`
+ * environment variable. That's only useful on systems that treat realtime
+ * priority as a scheduling or CPU placement signal, since everything that runs
+ * on those threads before the first process call still runs at this priority.
+ * The environment variable is read once, and the value is clamped to the valid
+ * `SCHED_FIFO` range and to the `RLIMIT_RTPRIO` limit so that a nonsensical
+ * value can't leave the thread on `SCHED_OTHER`.
+ */
+int fallback_realtime_priority() noexcept;
+
+/**
+ * Set the scheduling policy to `SCHED_FIFO` for this process. We explicitly
+ * don't do this for wineserver itself since from my testing that can actually
+ * increase latencies.
  *
  * @param sched_fifo If true, set the current process/thread's scheudling policy
  *   to `SCHED_FIFO`. Otherwise reset it back to `SCHWED_OTHER`.
  * @param priority The scheduling priority to use. The exact value usually
  *   doesn't really matter unless there are a lot of other active `SCHED_FIFO`
- *   background tasks. We'll use 5 as a default, but we'll periodically copy the
- *   priority set by the host on the audio threads.
+ *   background tasks. We'll use `fallback_realtime_priority()` as a default,
+ *   but we'll periodically copy the priority set by the host on the audio
+ *   threads.
  *
  * @return Whether the operation was successful or not. This will fail if the
  *   user does not have the privileges to set realtime priorities.
@@ -107,7 +121,9 @@ std::optional<int> get_realtime_priority() noexcept;
  *       propagate to a Windows plugin's audio threads, and I don't think
  *       there's a way to go back once you've set `SCHED_RESET_ON_FORK`.
  */
-bool set_realtime_priority(bool sched_fifo, int priority = 5) noexcept;
+bool set_realtime_priority(
+    bool sched_fifo,
+    int priority = fallback_realtime_priority()) noexcept;
 
 /**
  * Get the (soft) `RLIMIT_MEMLOCK` resource limit. If this is set to some low


### PR DESCRIPTION
### Summary

The Wine-side audio handler thread is created at `SCHED_FIFO` **5** and only learns the
host's real audio priority when the first `process()` call arrives. Everything that runs
on that thread before then — `setupProcessing()`, `setActive(true)`, `setProcessing(true)`
— runs at priority 5. For Kontakt that window contains the expensive activation, and on a
system that uses realtime priority as a scheduling signal it lands in the wrong place.

This PR does not try to close that window — that looks harder than it sounds, see below.
It makes the fallback `5` configurable, which is a much smaller change and enough to fix
it from the outside.

### Where the 5 comes from

`src/common/utils.h`, before this PR:

```cpp
bool set_realtime_priority(bool sched_fifo, int priority = 5) noexcept;
```

with the doc comment: *"The exact value usually doesn't really matter unless there are a
lot of other active `SCHED_FIFO` background tasks. We'll use 5 as a default, but we'll
periodically copy the priority set by the host on the audio threads."*

`src/wine-host/bridges/vst3.cpp`, in `register_object_instance()` — the audio handler
thread takes the default, then names itself:

```cpp
set_realtime_priority(true);
const std::string thread_name = "audio-" + std::to_string(instance_id);
pthread_setname_np(pthread_self(), thread_name.c_str());
```

The host's priority arrives only via the `Process` request:

```cpp
// src/wine-host/bridges/vst3.cpp, YaAudioProcessor::Process handler
if (request.new_realtime_priority) {
    set_realtime_priority(true, *request.new_realtime_priority);
}
```

and `src/plugin/bridges/vst3-impls/plugin-proxy.cpp` populates that field **only** in
`Vst3PluginProxyImpl::process()`, gated on
`audio_thread_priority_synchronization_interval` (= 10). `setActive()`,
`setProcessing()` and `setupProcessing()` never carry it. Same shape for CLAP
(`clap.cpp:1118`) and VST2 (`vst2.cpp:294`).

So the priority-5 window is exactly *thread creation → first `process()` call*.

### Why it matters here

Analyzed on a hybrid CPU (Intel i9-13900K: 16 P-core threads at 5.5–5.8 GHz, 16 E-cores at
4.3 GHz with much lower IPC). Bitwig's process tree is pinned to the P-cores and a helper
re-splits it by realtime priority: threads at rtprio ≥ 50 keep the P-cores, everything
else goes to the E-cores. That is the split that made the session viable at all — it took
Bitwig's Load MAX from 14.8 ms to 0.9 ms against a 5.333 ms deadline, purely by placement,
at about 6 % aggregate load per P-core.

The `audio-N` thread at FIFO 5 reads as "not an audio thread" to that rule, so it starts
on an E-core. Measured at 2 ms sampling resolution, one Kontakt 6 loading cold:

| | |
|---|---|
| `audio-0` FIFO 5 on E-cores | t = 16.33 |
| activation callback lands | t = 17.128 |
| `audio-0` becomes FIFO 85 on P-cores | t = 17.33 |

That activation burned **1.619 ms on-CPU in a single 2 ms window against a 0.028 ms
median**, on an E-core. Bitwig's own audio thread never exceeded 0.353 ms in the same
window — it was blocked waiting on the plugin, and reported the sum as Load MAX 1.861 ms.

Promoting the thread by name before activation brought that to 0.945 ms, and Load MAX
1.861 → **1.192 ms**. Quantum unchanged at 256/48000.

To be clear about what those numbers are: they come from an out-of-tree experiment that
promoted the thread by name from outside yabridge, not from this patch. What this patch
does is let the thread be created at that priority in the first place, which I have
verified at the thread level (see Testing below); the full DAW-level re-measurement is
still on my list.

Full write-up, including the sampling-rate finding (at 20 ms a window holds ~3.75
callbacks and averages the expensive one away, which is why this was invisible for a
while): <https://github.com/cheldt/bitwig-rt-tuning/blob/main/docs/dsp-spike-investigation.md>

### What this PR does

Adds a `YABRIDGE_FALLBACK_RT_PRIORITY` environment variable. `set_realtime_priority()`'s
default argument becomes a call to a new `fallback_realtime_priority()`, which reads the
variable once, ignores anything that isn't a plain number, and clamps the result to
`sched_get_priority_min(SCHED_FIFO)`…`sched_get_priority_max(SCHED_FIFO)` and to the soft
`RLIMIT_RTPRIO`. Unset or invalid gives 5, so the default is unchanged. Three files plus
the changelog: `src/common/utils.h`, `src/common/utils.cpp`, `README.md`. The variable is
documented as a bullet in the readme's "Performance tuning" section, next to the existing
realtime scheduling advice, rather than as a `yabridge.toml` compatibility option.

Because it's the default argument that changed, every call site that doesn't pass an
explicit priority picks it up — the plugin-side `host-callbacks` threads, the Wine-side
`run()` thread, and the per-instance `audio-N` thread alike, plus the plugin's own threads
that inherit the policy from the promote/demote pair around plugin construction. The three
sites that do pass the host's own priority are untouched.

The `RLIMIT_RTPRIO` part is there because clamping to the scheduler maximum alone isn't
enough: I tested with `=999` on a machine whose `rtprio` limit is 98, the clamp produced
99, `sched_setscheduler()` failed, and the thread silently stayed on `SCHED_OTHER` — which
is worse than the priority 5 it was trying to replace. With the rlimit taken into account
it lands at 98.

**On the choice of an environment variable over a `yabridge.toml` key** — happy to change
this if you'd rather have it as a config option, it's a small change either way. Two
reasons I went with the env var:

- The environment reaches every `set_realtime_priority()` call site at once, because
  `PluginInfo::create_host_env()` passes all of `environ` through to the Wine host. The
  `Configuration` object only arrives on the Wine side inside the bridge constructor via
  the `WantsConfiguration` message, so a config key would miss the plugin-side threads and
  `Vst3Bridge::run()`, and it would need a new field in `Configuration`'s bitsery
  serialization.
- An rtprio threshold is a property of the machine, not of a plugin, so a per-plugin
  option seemed like the wrong granularity for it.

### The alternative, if you'd rather close the window properly

Carry the last known host audio priority on `SetupProcessing` / `SetActive` /
`SetProcessing` requests as well as `Process`. Worth flagging that the obvious
implementation doesn't work: `get_realtime_priority()` reads the *calling* thread, and
`setActive()` is not called from the host's audio thread, so it would return `nullopt`
there. It needs a value cached from a previous `process()` — which means the first
instance created in a session still has nothing to send. That's why I went for the
configurable fallback instead.

### Not asking for

Raising the default from 5 for everyone. The reasoning in the existing comment is sound
for a normal setup; this only bites when realtime priority is being used as a placement
signal.

### Testing

- Builds clean with `ninja -C build` (no new warnings at `warning_level=3`), and
  `clang-format` is clean on both touched C++ files.
- Parsing, on a machine with an `rtprio` limit of 98: `(unset)`, `""`, `60`, `abc`,
  `12x`, `0`, `-3`, `999` → `5, 5, 60, 5, 5, 1, 1, 98`.
- End to end through a VST3 plugin (Sugar Bytes Bite), driven by a minimal host that calls
  `createInstance()` → `initialize()` → `setupProcessing()` → `setActive(true)` →
  `setProcessing(true)`, reading the Wine host's threads back with
  `ps -L -o tid,cls,rtprio,comm`:

  | `YABRIDGE_FALLBACK_RT_PRIORITY` | `audio-0` |
  |---|---|
  | unset | `FF 5` |
  | `60` | `FF 60` |
  | `1` | `FF 1` |
  | `abc` | `FF 5` |
  | `999` | `FF 98` (clamped to the `rtprio` limit) |

### Environment

- yabridge `5.1.1-57-gb580a9f7` (upstream `master`)
- Wine 11.16 TkG staging, ntsync
- Bitwig Studio, plugin sandboxing "By Plugin"
- Kontakt 6 / Kontakt 7 / FM8 via yabridge
- Linux 7.2.2 (CachyOS, RT/BORE), PipeWire 1.6.8, quantum 256/48000