### PR TITLE
Wine host working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The Wine plugin host now starts in the Wine prefix's `drive_c` directory
+  instead of inheriting the host's working directory. That directory is usually
+  not part of the Wine prefix, in which case Wine maps it to `Z:\`. Since that
+  drive's root is the Linux filesystem root it is not writable, so plugins that
+  create files relative to the root of the current drive would fail in ways that
+  look like a crash. This caused **Kontakt 7** and **Komplete Kontrol** to take
+  down the plugin host while an instance was being created.
 - Fixed a compatibility issue with **Wine 9.22** and above that caused mouse
   clicks in plugin GUIs to not register properly. A massive thanks to
   [@rbernon](https://github.com/rbernon),

--- a/src/common/process.cpp
+++ b/src/common/process.cpp
@@ -246,6 +246,31 @@ std::optional<int> Process::Handle::wait() const noexcept {
     }
 }
 
+/**
+ * Add a working directory change to a `posix_spawn_file_actions_t`. If glibc is
+ * too old to support this then the spawned process will just inherit our
+ * working directory, which is what it would have done before.
+ */
+static void add_start_dir_action(posix_spawn_file_actions_t& actions,
+                                 const fs::path& start_dir) {
+#if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 29)
+    posix_spawn_file_actions_addchdir_np(&actions, start_dir.c_str());
+#else
+    // NOTE: This is looked up at runtime for the same reason as
+    //       `posix_spawn_file_actions_addclosefrom_np()` below, namely so that
+    //       yabridge can still be compiled on older distros
+    int (*posix_spawn_file_actions_addchdir_np)(posix_spawn_file_actions_t*,
+                                                const char*);
+    posix_spawn_file_actions_addchdir_np =
+        reinterpret_cast<decltype(posix_spawn_file_actions_addchdir_np)>(
+            dlsym(nullptr, "posix_spawn_file_actions_addchdir_np"));
+
+    if (posix_spawn_file_actions_addchdir_np) {
+        posix_spawn_file_actions_addchdir_np(&actions, start_dir.c_str());
+    }
+#endif
+}
+
 Process::Process(std::string command) : command_(command) {}
 
 Process::StringResult Process::spawn_get_stdout_line() const {
@@ -265,6 +290,9 @@ Process::StringResult Process::spawn_get_stdout_line() const {
                                      O_WRONLY | O_APPEND, 0);
     posix_spawn_file_actions_addclose(&actions, stdout_pipe_fds[0]);
     posix_spawn_file_actions_addclose(&actions, stdout_pipe_fds[1]);
+    if (start_dir_) {
+        add_start_dir_action(actions, *start_dir_);
+    }
 
     pid_t child_pid = 0;
     const auto result = posix_spawnp(&child_pid, command_.c_str(), &actions,
@@ -306,9 +334,17 @@ Process::StatusResult Process::spawn_get_status() const {
     const auto argv = build_argv();
     const auto envp = env_ ? env_->make_environ() : environ;
 
+    // We only need file actions if we have to change the working directory
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    if (start_dir_) {
+        add_start_dir_action(actions, *start_dir_);
+    }
+
     pid_t child_pid = 0;
-    const auto result = posix_spawnp(&child_pid, command_.c_str(), nullptr,
-                                     nullptr, argv, envp);
+    const auto result =
+        posix_spawnp(&child_pid, command_.c_str(),
+                     start_dir_ ? &actions : nullptr, nullptr, argv, envp);
     if (result == 2) {
         return Process::CommandNotFound{};
     } else if (result != 0) {
@@ -392,6 +428,9 @@ Process::HandleResult Process::spawn_child_piped(
                                      STDERR_FILENO);
     // We'll close the four pipe fds along with the rest of the file descriptors
     close_non_stdio_file_descriptors(actions);
+    if (start_dir_) {
+        add_start_dir_action(actions, *start_dir_);
+    }
 
     pid_t child_pid = 0;
     const auto result = posix_spawnp(&child_pid, command_.c_str(), &actions,
@@ -438,6 +477,9 @@ Process::HandleResult Process::spawn_child_redirected(
     posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, filename.c_str(),
                                      O_WRONLY | O_CREAT | O_APPEND, 0640);
     close_non_stdio_file_descriptors(actions);
+    if (start_dir_) {
+        add_start_dir_action(actions, *start_dir_);
+    }
 
     pid_t child_pid = 0;
     const auto result = posix_spawnp(&child_pid, command_.c_str(), &actions,

--- a/src/common/process.h
+++ b/src/common/process.h
@@ -233,6 +233,16 @@ class Process {
     }
 
     /**
+     * Start the process in this directory instead of inheriting our own working
+     * directory. The directory has to exist, since the process would otherwise
+     * fail to spawn at all.
+     */
+    inline Process& start_dir(ghc::filesystem::path dir) {
+        start_dir_ = std::move(dir);
+        return *this;
+    }
+
+    /**
      * Spawn the process, leave STDIN, redirect STDERR to `/dev/null`, and
      * return the first line (without the trailing linefeed) of STDOUT. The
      * first output line will still be returned even if the process exits with a
@@ -280,6 +290,7 @@ class Process {
     std::string command_;
     std::vector<std::string> args_;
     std::optional<ProcessEnvironment> env_;
+    std::optional<ghc::filesystem::path> start_dir_;
 
     mutable std::vector<char const*> argv_;
 };

--- a/src/plugin/host-process.cpp
+++ b/src/plugin/host-process.cpp
@@ -57,6 +57,19 @@ Process::Handle HostProcess::launch_host(
     }
 
     child.environment(plugin_info.create_host_env());
+
+    // NOTE: Without this the Wine host inherits our working directory. That
+    //       directory is usually not part of the Wine prefix, so Wine maps it
+    //       to `Z:\`, which is the Linux filesystem root and thus not writable.
+    //       Plugins that create files relative to the root of the current drive
+    //       then fail in ways that look like a crash. The libzmq version
+    //       bundled with Kontakt 7 and Komplete Kontrol aborts the process this
+    //       way when it sets up its internal socket pair.
+    const fs::path drive_c = plugin_info.normalize_wine_prefix() / "drive_c";
+    if (fs::is_directory(drive_c)) {
+        child.start_dir(drive_c);
+    }
+
     Process::Handle child_handle = std::visit(
         overload{
             [](Process::Handle handle) -> Process::Handle { return handle; },


### PR DESCRIPTION
### Summary

`yabridge-host.exe` inherits its working directory from the DAW. That directory is almost never inside the Wine prefix, so Wine maps it to `Z:\`, whose root is the Linux filesystem root and is not writable. Every Wine-hosted plugin therefore runs with `Z:\` as its current drive, and any plugin that creates a file or socket relative to the *current drive root* fails. Because the failure happens inside the plugin, it surfaces as an unexplained host crash.

This changes `Process` so it can start a child in a specific directory, and starts
the Wine host in the prefix's `drive_c`. The plugin then sees `C:\`, which is what
it would see on Windows.

### What the failure looks like

Bitwig marks `Kontakt 7.vst3` as `could_not_load_plugin`:

```
15:26:10.475  About to create a VST 3 plugin instance for … /…/.vst3/yabridge/Kontakt 7.vst3
15:27:04.247  Could not read repsonses: End of stream
15:27:04.247  Killing pluginhost process
15:27:04.247  Plugin host process exited with code: 9
```

The 53 s gap is the DAW waiting on a child that is already gone; exit code 9 is the DAW's own `kill`, not the plugin's crash. With `YABRIDGE_DEBUG_FILE` set, the real event shows up one second after instance creation:

```
Bad file descriptor (D:\NIBuild\3rdparty\zeromq-v4.3.4-R4\src\epoll.cpp:100)
```

The plugin loads fine (`Finished initializing …`) and dies during *instance
creation*.

### Cause

Kontakt 7 bundles libzmq 4.3.4. Its Windows signaler creates its internal
socketpair over `AF_UNIX`, with a path from msvcrt `tmpnam()` — `\sNNN.N/socket`, relative to the root of the **current drive**. With `WINEDEBUG=+winsock` and the host's cwd outside the prefix:

```
WSASocketW family AF_UNIX, type SOCK_STREAM …
bind socket 0x50c, addr { family AF_UNIX, path  }, len 2
bind failed, status 0xc000000d.                     ← STATUS_INVALID_PARAMETER
closesocket 0x50c
… one retry, same result …
Bad file descriptor (…epoll.cpp:100)
```

`make_fdpair` returns an invalid fd, `epoll_ctl` rejects it with `EBADF`, and
libzmq's `errno_assert` aborts the process (`wine: Unhandled exception 0x40000015`).

With a cwd inside `$WINEPREFIX/drive_c` the same call succeeds:

```
bind socket 0x564, addr { family AF_UNIX, path \s198./socket }, len 15
bind successfully bound to address { family AF_UNIX, path \s198./socket }
```

libzmq removes the `sNNN.N` directories on close, so `drive_c/` does not accumulate
them.

Two things that make this look like a Kontakt bug when it is not:

- **Standalone "works".** Kontakt 7 standalone launched from Bottles works because
  Bottles launches it with a cwd inside the bottle. Launched by hand from a shell —
  same runner, same prefix, same wineserver, Bottles' environment replicated — it
  aborts identically.
- **Everything else was ruled out**, each tested separately: the wineserver session,
  `WINENTSYNC`/`WINEFSYNC`, `STAGING_SHARED_MEMORY`, Wayland vs X11, CPU pinning,
  and realtime priorities. The working directory is the only variable that changes
  the outcome.

### Why this can't be worked around outside yabridge

The working directory is inherited across fork/exec, so a `cd` before launching the
DAW looks like it should reach the plugin hosts. It does not: Bitwig chdirs
`BitwigAudioEngine` and `BitwigPluginHost` to `~/.BitwigStudio/log` itself, and the
crash comes back unchanged. Verified.

A wrapper that shadows `yabridge-host.exe` on `PATH` does work, but shadowing the
host's name also moves where yabridge looks for everything else — each chainloader
takes the directory of the *first* `yabridge-host.exe` on `PATH` and `dlopen`s
`libyabridge-vst3.so` from there (`src/chainloader/utils.h`), so the libraries have
to be duplicated next to the wrapper and `find_plugin_library`'s
`${XDG_DATA_HOME:-$HOME/.local/share}/yabridge` fallback never gets a chance. A user
who wraps the host the obvious way gets a plugin that fails to load with the real
host sitting right there.

### Implementation

- `Process::start_dir()` stores an optional working directory, applied through
  `posix_spawn_file_actions_addchdir_np()` in all four spawn functions. That
  function needs glibc 2.29, so it is looked up at runtime on older glibc versions
  in the same way `posix_spawn_file_actions_addclosefrom_np()` already is. If it is
  unavailable the child simply inherits our working directory, which is the old
  behaviour.
- `HostProcess::launch_host()` sets it to `normalize_wine_prefix() / "drive_c"`.
  The prefix is already resolved for the group host socket name, so nothing new has
  to be detected. It is only set when the directory actually exists — a `chdir`
  failure would make `posix_spawn()` fail outright, and a misconfigured prefix
  should not stop the host from launching.

Setting the Unix working directory rather than calling `SetCurrentDirectory()` in
`host.cpp` means the directory is in place before the Wine loader runs, and it does
not hardcode a drive letter.

### Testing

Built against `master`, tested with `carla-single` from a working directory outside
the prefix, which is what a DAW gives its plugin hosts. Identical invocations, only
the patch differs:

| | `ps -o stat=` on `yabridge-host.e` | outcome |
|---|---|---|
| before | `S` → `Z` within ~6 s | host dies during instance creation |
| after | `S<Ll` for the whole run | plugin loads, GUI comes up |

`readlink /proc/<pid>/cwd` on the running host confirms
`…/Native-Access/drive_c` instead of the shell's directory.

Also checked:

- FabFilter Pro-Q 4 (no libzmq) still loads, with and without `WINEPREFIX` set, so
  the auto-detected prefix path works too.
- A plugin group (`group = "test-group"`) still starts: `Group host is up and
  running, now accepting incoming connections`, plugin initializes, and the group
  host process has the same working directory.

### Note

`bind … { family AF_UNIX, path  }, len 2` shows that msvcrt's `tmpnam()` returns an
**empty** name rather than `NULL` when the current drive root is not writable. On
Windows it returns `NULL` if it cannot create a name, and libzmq checks for that; an
empty string passes the check. That looks like a separate Wine bug and I will report
it against `msvcrt` on its own.

### Environment

- Wine 11.16 TkG staging, ntsync
- Bitwig Studio 5.x and `carla-single` (both reproduce)
- Linux 7.2.2 (CachyOS)